### PR TITLE
Fix -v verbose flag not lowering handler log level

### DIFF
--- a/src/actual_budget_transformer/main.py
+++ b/src/actual_budget_transformer/main.py
@@ -112,9 +112,13 @@ def main():
 
     args = parser.parse_args()
 
-    # Set logging level based on verbosity
+    # Set logging level based on verbosity. The level must be lowered on both
+    # the logger and its handlers, otherwise handlers pinned at INFO would
+    # filter out DEBUG records even when the logger accepts them.
     if args.verbose:
         logger.setLevel(logging.DEBUG)
+        for handler in logger.handlers:
+            handler.setLevel(logging.DEBUG)
 
     # Load configuration from file if provided. This will cache it for other modules.
     load_config(args.config_path)


### PR DESCRIPTION
## Problem

Running the transformer with `-v/--verbose` did not actually surface DEBUG logging, so processor `can_process` rejection reasons (e.g. why `transactions-3.csv` gets "No processor found") were invisible.

## Cause

`setup_logging()` pins the console handler at INFO:

```python
console_handler.setLevel(level)  # level defaults to INFO
```

On `--verbose`, `main.py` only lowered the **logger** level to DEBUG. The **handler** stayed at INFO and filtered out every DEBUG record, so nothing extra printed.

## Fix

When `--verbose` is set, lower the level on the logger's handlers too. DEBUG records now reach the console.

Verified: before the change the handler stays at INFO and DEBUG lines are swallowed; after, they print.

🤖 Generated with [Claude Code](https://claude.com/claude-code)